### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 The MCP connects to the TMAP API.
 
+<a href="https://glama.ai/mcp/servers/@yunkee-lee/mcp-tmap">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@yunkee-lee/mcp-tmap/badge" alt="TMAP Server MCP server" />
+</a>
+
 It currently supports the following APIs:
 * [Public Transit API](https://openapi.sk.com/products/detail?svcSeq=59&menuSeq=394)
   * Transit route


### PR DESCRIPTION
This PR adds a badge for the [MCP TMAP Server](https://glama.ai/mcp/servers/@yunkee-lee/mcp-tmap) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@yunkee-lee/mcp-tmap">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@yunkee-lee/mcp-tmap/badge" alt="TMAP Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.